### PR TITLE
Archive this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]  
+> This repo is archived, please see our new HTML/CSS starter kit [Amplify](https://github.com/studio24/amplify).
+
 # Apollo
 
 This is a static (HTML, CSS and Javascript) framework with performance and accessibility as first-class passenger.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]  
-> This repo is archived, please see our new HTML/CSS starter kit [Amplify](https://github.com/studio24/amplify).
+> This repo is archived, please see our new front-end starter kit [Amplify](https://github.com/studio24/amplify).
 
 # Apollo
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 This is a static (HTML, CSS and Javascript) framework with performance and accessibility as first-class passenger.
 
-_Please note the new version of Apollo is being actively developed in the [apollo-v2](https://github.com/studio24/apollo/tree/apollo-v2) branch and is planned for completion in early 2020._
-
 ## What is this repository for?
 
 Apollo is used in the Studio24 Wordpress starter theme with the same name. It's part of the [Wordpress installer script](https://bitbucket.org/studio24/wordpress-installation-script). The following file(s) and folder(s) should be deleted after installation. They are used for this repository itself and are not needed when used in the theme.


### PR DESCRIPTION
It would be good to archive this project and point people to Amplify, I've suggested some text. Once merged this project can be archived. 

I'd also recommend we take https://apollo.studio24.net/ offline and redirect this to https://amplify.studio24.net/

Or is there value leaving this online for now?